### PR TITLE
fix calls to plotmodelfield_skytem in SkyTEM1DInversion.jl

### DIFF
--- a/src/SkyTEM1DInversion.jl
+++ b/src/SkyTEM1DInversion.jl
@@ -3,7 +3,7 @@ import AbstractOperator.get_misfit
 using AbstractOperator, AEM_VMD_HMD, Statistics
 using TransD_GP, PyPlot, LinearAlgebra, CommonToAll, MAT, Random, DelimitedFiles
 
-export dBzdt, plotmodelfield!, addnoise_skytem, plotmodelfield!
+export dBzdt, plotmodelfield!, addnoise_skytem, plotmodelfield!, plotmodelfield_skytem!
 
 const μ₀ = 4*pi*1e-7
 
@@ -283,7 +283,7 @@ function addnoise_skytem(Flow::AEM_VMD_HMD.HField, Fhigh::AEM_VMD_HMD.HField,
     dhigh[abs.(dhigh).<noisefloorhigh] .= NaN
     σlow = noisefrac*abs.(dlow)
     σhigh = noisefrac*abs.(dhigh)
-    plotmodelfield_skytem!(Flow, Fhigh, z, ρ, dlow, dhigh, σlow, σhigh,
+    plotmodelfield!(Flow, Fhigh, z, ρ, dlow, dhigh, σlow, σhigh,
                                 figsize=figsize, nfixed=nfixed,
                                 dz=dz, extendfrac=extendfrac)
     # returned data is dBzdt not H if there is a μ multiplied


### PR DESCRIPTION
Hi Anand,

Was trying to run the simple stationary GP SkyTEM inversion on my VM and I noticed that `SkyTEM1DInversion.jl` doesn't export `plotmodelfield_skytem!` and `addnoise_skytem` tries to call `plotmodelfield!` with some keyword arguments it doesn't support - I switched this call to `plotmodelfield_skytem!` and exported the functions that the stationary GP inversion requires, and it at least runs now, but I'm not sure how the functions in `SkyTEM1DInversion.jl` are supposed to be set up so I'm doing this as a pull request in case it breaks something I didn't notice.